### PR TITLE
fix: get oauthHost from current window

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VITE_OAUTH_HOST=https://gitmaya.com
+VITE_OAUTH_HOST=

--- a/src/hooks/useOauthDialog.ts
+++ b/src/hooks/useOauthDialog.ts
@@ -15,7 +15,13 @@ export const useOauthDialog = ({
   callback: (data: unknown) => void;
 }) => {
   const dialog = useRef<Window | null>();
-  const _url = oauthHost + url;
+  let _url = '';
+  if (oauthHost.length > 0) {
+    _url = oauthHost + url;
+  }
+  else {
+    _url = window.location.origin + url;
+  }
 
   const eventListener = useCallback(
     (e: MessageEvent) => {


### PR DESCRIPTION
如果部署 GitMaya 的用户采用的是直接从远程拉取 Docker 镜像进行部署，则无法修改环境变量中的 `oauthHost`，造成在 OAuth 和 Install 时无法跳转到正确的部署地址，进而无法完成正确流程。

